### PR TITLE
Добавление типов размеров фотографий, не присутствующих в документации

### DIFF
--- a/vkbottle_types/objects.py
+++ b/vkbottle_types/objects.py
@@ -4965,6 +4965,19 @@ class PhotosPhotoSizesType(enum.Enum):
     I = "i"
     D = "d"
 
+    # undocumented sizes
+    A = "a"
+    B = "b"
+    E = "e"
+    F = "f"
+    G = "g"
+    H = "h"
+    J = "j"
+    N = "n"
+    T = "t"
+    U = "u"
+    V = "v"
+
 
 class PhotosPhotoTag(BaseModel):
     """VK Object Photos/PhotosPhotoTag


### PR DESCRIPTION
В [документации ВК](https://vk.com/dev/photo_sizes) есть перечисление типов размеров фотографий, но на данный момент оно не является актуальным и по факту в ответах приходят и другие типы. Для того, чтобы валидация ответа не валилась из-за неверного типа размера, лучше добавить туда сразу весь алфавит.