### PR TITLE
feat(events): make `GroupEventType` string enum

### DIFF
--- a/vkbottle_types/events/enums/group_events.py
+++ b/vkbottle_types/events/enums/group_events.py
@@ -1,5 +1,3 @@
-import enum
-
 from .str_enum import StrEnum
 
 

--- a/vkbottle_types/events/enums/group_events.py
+++ b/vkbottle_types/events/enums/group_events.py
@@ -1,7 +1,9 @@
 import enum
 
+from .str_enum import StrEnum
 
-class GroupEventType(enum.Enum):
+
+class GroupEventType(StrEnum):
     MESSAGE_NEW = "message_new"
     MESSAGE_REPLY = "message_reply"
     MESSAGE_EDIT = "message_edit"

--- a/vkbottle_types/events/enums/str_enum.py
+++ b/vkbottle_types/events/enums/str_enum.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class StrEnum(str, Enum):
+    def __str__(self) -> str:
+        return str(self.value)


### PR DESCRIPTION
Так как все значения `GroupEventType` являются строками, его можно использовать там, где ожидаются строки, что позволит сократить `Union[GroupEventType, str]` до `str`